### PR TITLE
Fix truncated files block size

### DIFF
--- a/dedupsqlfs/db/migration.py
+++ b/dedupsqlfs/db/migration.py
@@ -51,6 +51,9 @@ class DbMigration( object ):
 
         migration = tableOpts.get("migration")
         if not migration:
+            inited = tableOpts.get("inited")
+            if not inited:
+                return False
             return True
         else:
             migration = int(migration)

--- a/dedupsqlfs/db/sqlite/table/hash.py
+++ b/dedupsqlfs/db/sqlite/table/hash.py
@@ -84,7 +84,7 @@ class TableHash( Table ):
         cur = self.getCursor()
         cur.execute("SELECT `id` FROM `%s` " % self.getName()+
                     " WHERE `id`>=? AND `id`<?", (start_id, end_id,))
-        nameIds = set(str(item["id"]) for item in iter(cur.fetchone, None))
+        nameIds = set(item["id"] for item in iter(cur.fetchone, None))
         self.stopTimer('get_hash_ids')
         return nameIds
 

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -148,7 +148,7 @@ class TableInode( Table ):
     def get_count(self):
         self.startTimer()
         cur = self.getCursor()
-        cur.execute("SELECT COUNT(1) as cnt FROM `%s` WHERE `nlinks` > 0" % self.getName())
+        cur.execute("SELECT COUNT(1) as cnt FROM `%s`" % self.getName())
         item = cur.fetchone()
         self.stopTimer('get_count')
         return item["cnt"]
@@ -172,7 +172,7 @@ class TableInode( Table ):
         if id_str:
             cur = self.getCursor()
             cur.execute("SELECT `id`,`size` FROM `%s`" % self.getName()+
-                        " WHERE id in (%s) AND `nlinks`>0" % id_str)
+                        " WHERE id in (%s)" % id_str)
             for item in iter(cur.fetchone, None):
                 items[ str(item["id"]) ] = item["size"]
 
@@ -200,7 +200,7 @@ class TableInode( Table ):
         self.startTimer()
         cur = self.getCursor()
         cur.execute("SELECT `id` FROM `%s` " % self.getName()+
-                    " WHERE `id`>=? AND `id`<? AND `nlinks`>0", (start_id, end_id,))
+                    " WHERE `id`>=? AND `id`<?", (start_id, end_id,))
         nameIds = set(str(item["id"]) for item in iter(cur.fetchone,None))
         self.stopTimer('get_inode_ids')
         return nameIds
@@ -225,7 +225,7 @@ class TableInode( Table ):
         if id_str:
             cur = self.getCursor()
             cur.execute("SELECT `id` FROM `%s` " % self.getName()+
-                            " WHERE `id` IN (%s) AND `nlinks`>0" % (id_str,))
+                            " WHERE `id` IN (%s)" % (id_str,))
             iids = set(str(item["id"]) for item in iter(cur.fetchone,None))
 
         self.stopTimer('get_inodes_by_inodes')

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -187,7 +187,7 @@ class TableInode( Table ):
         cur = self.getCursor()
         cur.execute("SELECT `id` FROM `%s` " % self.getName()+
                     " WHERE `id`>=? AND `id`<?", (start_id, end_id,))
-        nameIds = tuple(str(item["id"]) for item in iter(cur.fetchone,None))
+        nameIds = set(str(item["id"]) for item in iter(cur.fetchone,None))
         self.stopTimer('get_inode_ids')
         return nameIds
 

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -165,6 +165,20 @@ class TableInode( Table ):
         self.stopTimer('get_sizes')
         return item
 
+    def get_sizes_by_id(self, inodes):
+        self.startTimer()
+        items = {}
+        id_str = ",".join(inodes)
+        if id_str:
+            cur = self.getCursor()
+            cur.execute("SELECT `id`,`size` FROM `%s`" % self.getName()+
+                        " WHERE id in (%s) `nlinks`>0" % id_str)
+            for item in iter(cur.fetchone(), None):
+                items[ item["id"] ] = item["size"]
+
+        self.stopTimer('get_sizes_by_id')
+        return items
+
     def get_sizes_by_inodes(self, inodes):
         self.startTimer()
 

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -173,7 +173,7 @@ class TableInode( Table ):
             cur = self.getCursor()
             cur.execute("SELECT `id`,`size` FROM `%s`" % self.getName()+
                         " WHERE id in (%s) AND `nlinks`>0" % id_str)
-            for item in iter(cur.fetchone(), None):
+            for item in iter(cur.fetchone, None):
                 items[ item["id"] ] = item["size"]
 
         self.stopTimer('get_sizes_by_id')

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -174,7 +174,7 @@ class TableInode( Table ):
             cur.execute("SELECT `id`,`size` FROM `%s`" % self.getName()+
                         " WHERE id in (%s) AND `nlinks`>0" % id_str)
             for item in iter(cur.fetchone, None):
-                items[ item["id"] ] = item["size"]
+                items[ str(item["id"]) ] = item["size"]
 
         self.stopTimer('get_sizes_by_id')
         return items

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -172,7 +172,7 @@ class TableInode( Table ):
         if id_str:
             cur = self.getCursor()
             cur.execute("SELECT `id`,`size` FROM `%s`" % self.getName()+
-                        " WHERE id in (%s) `nlinks`>0" % id_str)
+                        " WHERE id in (%s) AND `nlinks`>0" % id_str)
             for item in iter(cur.fetchone(), None):
                 items[ item["id"] ] = item["size"]
 

--- a/dedupsqlfs/db/sqlite/table/inode.py
+++ b/dedupsqlfs/db/sqlite/table/inode.py
@@ -148,7 +148,7 @@ class TableInode( Table ):
     def get_count(self):
         self.startTimer()
         cur = self.getCursor()
-        cur.execute("SELECT COUNT(1) as cnt FROM `%s`" % self.getName())
+        cur.execute("SELECT COUNT(1) as cnt FROM `%s` WHERE `nlinks` > 0" % self.getName())
         item = cur.fetchone()
         self.stopTimer('get_count')
         return item["cnt"]
@@ -200,7 +200,7 @@ class TableInode( Table ):
         self.startTimer()
         cur = self.getCursor()
         cur.execute("SELECT `id` FROM `%s` " % self.getName()+
-                    " WHERE `id`>=? AND `id`<?", (start_id, end_id,))
+                    " WHERE `id`>=? AND `id`<? AND `nlinks`>0", (start_id, end_id,))
         nameIds = set(str(item["id"]) for item in iter(cur.fetchone,None))
         self.stopTimer('get_inode_ids')
         return nameIds
@@ -225,7 +225,7 @@ class TableInode( Table ):
         if id_str:
             cur = self.getCursor()
             cur.execute("SELECT `id` FROM `%s` " % self.getName()+
-                            " WHERE `id` IN (%s)" % (id_str,))
+                            " WHERE `id` IN (%s) AND `nlinks`>0" % (id_str,))
             iids = set(str(item["id"]) for item in iter(cur.fetchone,None))
 
         self.stopTimer('get_inodes_by_inodes')

--- a/dedupsqlfs/db/sqlite/table/inode_hash_block.py
+++ b/dedupsqlfs/db/sqlite/table/inode_hash_block.py
@@ -74,6 +74,16 @@ class TableInodeHashBlock( Table ):
         self.stopTimer('delete_by_inode_number')
         return item
 
+    def delete_by_inode_number_more( self, inode, block_number ):
+        self.startTimer()
+        cur = self.getCursor()
+        cur.execute("SELECT block_number FROM `%s` WHERE inode_id=? AND block_number>?" % self.getName(), (inode, block_number,))
+        items = cur.fetchall()
+        if items:
+            cur.execute("DELETE FROM `%s` WHERE inode_id=? AND block_number>?" % self.getName(), (inode, block_number,))
+        self.stopTimer('delete_by_inode_number_more')
+        return items
+
     def get_count_uniq_inodes(self):
         self.startTimer()
         cur = self.getCursor()
@@ -91,7 +101,7 @@ class TableInodeHashBlock( Table ):
         cur = self.getCursor()
         cur.execute("SELECT DISTINCT `inode_id` FROM `%s` " % self.getName()+
                     " WHERE `inode_id`>=? AND `inode_id`<?", (start_id, end_id,))
-        nameIds = tuple(str(item["inode_id"]) for item in iter(cur.fetchone,None))
+        nameIds = set(str(item["inode_id"]) for item in iter(cur.fetchone,None))
         self.stopTimer('get_inode_ids')
         return nameIds
 

--- a/dedupsqlfs/db/sqlite/table/name.py
+++ b/dedupsqlfs/db/sqlite/table/name.py
@@ -102,7 +102,7 @@ class TableName( Table ):
         cur = self.getCursor()
         cur.execute("SELECT `id` FROM `%s` " % self.getName()+
                     " WHERE `id`>=? AND `id`<?", (start_id, end_id,))
-        nameIds = set(str(item["id"]) for item in iter(cur.fetchone, None))
+        nameIds = set(item["id"] for item in iter(cur.fetchone, None))
         self.stopTimer('get_name_ids')
         return nameIds
 

--- a/dedupsqlfs/db/sqlite/table/tmp_ids.py
+++ b/dedupsqlfs/db/sqlite/table/tmp_ids.py
@@ -57,7 +57,7 @@ class TableTmpIds( Table ):
             cur = self.getCursor()
             cur.execute("SELECT `id` FROM `%s` " % self.getName()+
                             " WHERE `id` IN (%s)" % (id_str,))
-            ret_ids = tuple(str(item["id"]) for item in iter(cur.fetchone,None))
+            ret_ids = set(str(item["id"]) for item in iter(cur.fetchone,None))
         self.stopTimer('get_ids_by_ids')
         return ret_ids
 

--- a/dedupsqlfs/db/sqlite/table/tree.py
+++ b/dedupsqlfs/db/sqlite/table/tree.py
@@ -133,7 +133,7 @@ class TableTree( Table ):
             cur = self.getCursor()
             cur.execute("SELECT `inode_id` FROM `%s` " % self.getName()+
                             " WHERE `inode_id` IN (%s)" % (id_str,))
-            iids = tuple(str(item["inode_id"]) for item in iter(cur.fetchone,None))
+            iids = set(str(item["inode_id"]) for item in iter(cur.fetchone,None))
 
         self.stopTimer('get_inodes_by_inodes')
         return iids

--- a/dedupsqlfs/fuse/dedupfs.py
+++ b/dedupsqlfs/fuse/dedupfs.py
@@ -82,6 +82,7 @@ class DedupFS(object): # {{{1
         except Exception as e:
             error = True
             ex = e
+            self.getLogger().error(traceback.format_exc())
 
         if error:
             try:

--- a/dedupsqlfs/fuse/dedupfs.py
+++ b/dedupsqlfs/fuse/dedupfs.py
@@ -74,16 +74,25 @@ class DedupFS(object): # {{{1
 
         self._compressTool.init()
 
+        error = False
+        ex = None
         try:
             fuse.init(self.operations, self.mountpoint, self._opts)
             fuse.main(single=True)
-        except:
-            fuse.close(unmount=False)
-            self._compressTool.stop()
-            raise
+        except Exception as e:
+            error = True
+            ex = e
 
-        fuse.close()
+        if error:
+            try:
+                fuse.close(unmount=False)
+            except:
+                pass
+        else:
+            fuse.close()
         self._compressTool.stop()
+        if ex:
+            raise ex
 
     def parseFuseOptions(self, mountoptions):
         if not mountoptions:

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2091,7 +2091,7 @@ class DedupOperations(llfuse.Operations): # {{{1
 
         # 1. Remove blocks that has number more than MAX by size
         tableIndex = self.getTable("inode_hash_block")
-        items = tableIndex.delete_by_inode_number_more(max_block_number)
+        items = tableIndex.delete_by_inode_number_more(inode_id, max_block_number)
         for item in items:
             self.cached_indexes.unset(inode_id, item["block_number"])
 

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2157,6 +2157,7 @@ class DedupOperations(llfuse.Operations): # {{{1
             start_time = time.time()
             self.getLogger().debug("Performing garbage collection (this might take a while) ..")
             self.should_vacuum = False
+            clean_stats = False
             for method in self.__collect_strings, \
                           self.__collect_inodes_all, \
                           self.__collect_xattrs, \
@@ -2166,8 +2167,14 @@ class DedupOperations(llfuse.Operations): # {{{1
                 sub_start_time = time.time()
                 msg = method()
                 if msg:
+                    clean_stats = True
                     elapsed_time = time.time() - sub_start_time
                     self.getLogger().info(msg, format_timespan(elapsed_time))
+
+            if clean_stats:
+                subv = Subvolume(self)
+                subv.clean_stats(self.mounted_subvolume_name)
+
             elapsed_time = time.time() - start_time
             self.getLogger().debug("Finished garbage collection in %s.", format_timespan(elapsed_time))
         return

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2255,15 +2255,15 @@ class DedupOperations(llfuse.Operations): # {{{1
             current += len(inodeIds)
 
             curBlock += maxCnt
-            if not inodeIds:
+            if not len(inodeIds):
                 continue
 
             treeInodeIds = tableTree.get_inodes_by_inodes(inodeIds)
 
-            to_delete = ()
+            to_delete = set()
             for inode_id in inodeIds:
                 if inode_id not in treeInodeIds:
-                    to_delete += (inode_id,)
+                    to_delete.add(inode_id)
 
             count += tableInode.remove_by_ids(to_delete)
 

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2177,9 +2177,7 @@ class DedupOperations(llfuse.Operations): # {{{1
         tableName = self.getTable("name")
 
         subv = Subvolume(self)
-        subv.prepareTreeNameIds()
-
-        tableTmp = self.getTable("tmp_ids")
+        treeNameIds = subv.prepareTreeNameIds()
 
         self.getLogger().debug("Clean unused path segments...")
 
@@ -2206,8 +2204,6 @@ class DedupOperations(llfuse.Operations): # {{{1
             if not nameIds:
                 continue
 
-            treeNameIds = tableTmp.get_ids_by_ids(nameIds)
-
             to_delete = ()
             for name_id in nameIds:
                 if name_id not in treeNameIds:
@@ -2219,8 +2215,6 @@ class DedupOperations(llfuse.Operations): # {{{1
             if p != proc:
                 proc = p
                 self.getLogger().debug("%s (count=%d)", proc, count)
-
-        tableTmp.drop()
 
         if count > 0:
             self.should_vacuum = True
@@ -2457,9 +2451,7 @@ class DedupOperations(llfuse.Operations): # {{{1
         tableHSZ = self.getTable("hash_sizes")
 
         subv = Subvolume(self)
-        subv.prepareIndexHashIds()
-
-        tableTmp = self.getTable("tmp_ids")
+        indexHashIds = subv.prepareIndexHashIds()
 
         self.getLogger().debug("Clean unused data blocks and hashes...")
 
@@ -2486,8 +2478,6 @@ class DedupOperations(llfuse.Operations): # {{{1
             if not hashIds:
                 continue
 
-            indexHashIds = tableTmp.get_ids_by_ids(hashIds)
-
             to_delete = ()
             for hash_id in hashIds:
                 if hash_id not in indexHashIds:
@@ -2504,8 +2494,6 @@ class DedupOperations(llfuse.Operations): # {{{1
                 self.getLogger().debug("%s (count=%d)", proc, count)
 
         self.getManager().commit()
-
-        tableTmp.drop()
 
         if count > 0:
             self.should_vacuum = True

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2204,10 +2204,10 @@ class DedupOperations(llfuse.Operations): # {{{1
             if not nameIds:
                 continue
 
-            to_delete = ()
+            to_delete = set()
             for name_id in nameIds:
                 if name_id not in treeNameIds:
-                    to_delete += (name_id,)
+                    to_delete.add(str(name_id))
 
             count += tableName.remove_by_ids(to_delete)
 
@@ -2478,10 +2478,10 @@ class DedupOperations(llfuse.Operations): # {{{1
             if not hashIds:
                 continue
 
-            to_delete = ()
+            to_delete = set()
             for hash_id in hashIds:
                 if hash_id not in indexHashIds:
-                    to_delete += (hash_id,)
+                    to_delete.add(str(hash_id))
 
             count += tableHash.remove_by_ids(to_delete)
             tableBlock.remove_by_ids(to_delete)

--- a/dedupsqlfs/fuse/subvolume.py
+++ b/dedupsqlfs/fuse/subvolume.py
@@ -551,7 +551,28 @@ class Subvolume(object):
         tableSubvol.stats_time(subvolItem["id"])
         tableSubvol.set_stats(subvolItem["id"], json.dumps(stats))
 
+        tableSubvol.commit()
+
         return stats
+
+    def clean_stats(self, name):
+        if not name:
+            self.getLogger().error("Select subvolume which you need to process!")
+            return False
+
+        tableSubvol = self.getTable('subvolume')
+
+        subvolItem = tableSubvol.find(name)
+        if not subvolItem:
+            self.getLogger().error("Subvolume with name %r not found!" % name)
+            return False
+
+        tableSubvol.stats_time(subvolItem["id"], 0)
+        tableSubvol.set_stats(subvolItem["id"], None)
+
+        tableSubvol.commit()
+
+        return
 
     def report_usage(self, name):
         """

--- a/dedupsqlfs/fuse/subvolume.py
+++ b/dedupsqlfs/fuse/subvolume.py
@@ -190,12 +190,13 @@ class Subvolume(object):
     def prepareTreeNameIds(self):
         """
         List all subvolumes
+        @rtype: set
         """
 
         tableSubvol = self.getTable('subvolume')
-        tableTmp = self.getTable('tmp_ids')
-        tableTmp.drop()
-        tableTmp.create()
+
+        nameIds = set()
+        pageSize = 10000
 
         for subvol_id in tableSubvol.get_ids():
 
@@ -206,21 +207,31 @@ class Subvolume(object):
             curTree = tableTree.getCursor()
             curTree.execute("SELECT DISTINCT name_id FROM `%s`" % tableTree.getName())
 
-            for node in iter(curTree.fetchone, None):
-                if not tableTmp.find(node["name_id"]):
-                    tableTmp.insert(node["name_id"])
+            while True:
 
-        return
+                items = curTree.fetchmany(pageSize)
+
+                if not len(items):
+                    break
+
+                for node in items:
+
+                    name_id = node["name_id"]
+
+                    nameIds.add(name_id)
+
+        return nameIds
 
     def prepareIndexHashIds(self):
         """
         List all subvolumes
+        @rtype: set
         """
 
         tableSubvol = self.getTable('subvolume')
-        tableTmp = self.getTable('tmp_ids')
-        tableTmp.drop()
-        tableTmp.create()
+
+        hashIds = set()
+        pageSize = 10000
 
         for subvol_id in tableSubvol.get_ids():
 
@@ -234,26 +245,39 @@ class Subvolume(object):
 
             nodesInodes = {}
 
-            for item in iter(curIndex.fetchone, None):
+            while True:
 
-                # Check if FS tree has inode
+                items = curIndex.fetchmany(pageSize)
+                if not len(items):
+                    break
 
-                inode_id = str(item["inode_id"])
-                if inode_id in nodesInodes:
-                    if not nodesInodes[inode_id]:
-                        continue
-                else:
-                    node = tableTree.find_by_inode(inode_id)
-                    if not node:
-                        nodesInodes[inode_id] = False
-                        continue
+                inode_ids = ",".join(set(str(item["inode_id"]) for item in items))
+
+                inodes_in_tree = set(tableTree.get_inodes_by_inodes_intgen(inode_ids))
+
+                for item in items:
+
+                    # Check if FS tree has inode
+
+                    inode_id = item["inode_id"]
+                    if inode_id in nodesInodes:
+                        if not nodesInodes[inode_id]:
+                            continue
                     else:
-                        nodesInodes[inode_id] = True
+                        if inode_id not in inodes_in_tree:
+                            nodesInodes[inode_id] = False
+                            continue
+                        else:
+                            nodesInodes[inode_id] = True
 
-                if not tableTmp.find(item["hash_id"]):
-                    tableTmp.insert(item["hash_id"])
+                    hash_id = item["hash_id"]
+                    hashIds.add(hash_id)
 
-        return
+            curIndex.close()
+            tableIndex.close()
+            tableTree.close()
+
+        return hashIds
 
 
     def prepareIndexHashIdCount(self):

--- a/dedupsqlfs/fuse/subvolume.py
+++ b/dedupsqlfs/fuse/subvolume.py
@@ -215,10 +215,10 @@ class Subvolume(object):
                     break
 
                 for node in items:
+                    nameIds.add(node["name_id"])
 
-                    name_id = node["name_id"]
-
-                    nameIds.add(name_id)
+            curTree.close()
+            tableTree.close()
 
         return nameIds
 


### PR DESCRIPTION
- more use sets, not tuples - faster search
- use fetchmany and queries with id sets
- use memory not temporary tables - faster
- don't convert to str, use int keys, save some memory