### PR TITLE
Add recompression on the fly for deprecated compression methods.

### DIFF
--- a/dedupsqlfs/__init__.py
+++ b/dedupsqlfs/__init__.py
@@ -24,7 +24,7 @@ Copyright 2013-2015 Sergey Dryabzhinsky <sergey.dryabzhinsky@gmail.com>.
 __name__ = "DedupSQLfs"
 __fsversion__ = "3.1"
 # Future 1.3
-__version__ = "1.2.900"
+__version__ = "1.2.901"
 
 # Check the Python version, warn the user if untested.
 import sys

--- a/dedupsqlfs/app/mount.py
+++ b/dedupsqlfs/app/mount.py
@@ -169,7 +169,8 @@ def main(): # {{{1
                         help="Compression level ratio: one of %s; or INT. Defaults to %r. Not all methods support this option." % (
                             ', '.join('%r' % lvl for lvl in levels), constants.COMPRESSION_LEVEL_DEFAULT
                         ))
-    # Do not want 'best' after help setup
+
+    parser.add_argument('--recompress-on-fly', dest='compression_recompress_now', action="store_true", help="Do recompress blocks which compressed with deprecated compression method.")
 
     # Dynamically check for profiling support.
     try:

--- a/dedupsqlfs/compression/_base.py
+++ b/dedupsqlfs/compression/_base.py
@@ -22,6 +22,8 @@ class BaseCompression:
     _func_comp = None
     _func_decomp = None
 
+    _deprecated = False
+
     def __init__(self):
         if self._method_name is None:
             raise AttributeError("Attribute _method_name must be set!")
@@ -84,6 +86,13 @@ class BaseCompression:
         if self._minimal_size > data_len:
             return False
         return True
+
+    def isDeprecated(self):
+        """
+        Is (de)compression method deprecated and should not be used
+        @return: bool
+        """
+        return self._deprecated
 
     def compressData(self, data, comp_level=None):
         """

--- a/dedupsqlfs/compression/quicklz.py
+++ b/dedupsqlfs/compression/quicklz.py
@@ -16,6 +16,8 @@ class QuickLzCompression(BaseCompression):
 
     _minimal_size = 17
 
+    _deprecated = True
+
     _has_comp_level_options = False
 
     def isDataMayBeCompressed(self, data):

--- a/dedupsqlfs/compression/zstd001.py
+++ b/dedupsqlfs/compression/zstd001.py
@@ -16,6 +16,8 @@ class Zstd001Compression(BaseCompression):
 
     _has_comp_level_options = False
 
+    _deprecated = True
+
     _func_decomp_new = None
 
     def _init_module(self):

--- a/dedupsqlfs/compression/zstd036.py
+++ b/dedupsqlfs/compression/zstd036.py
@@ -17,6 +17,8 @@ class Zstd036Compression(BaseCompression):
 
     _has_comp_level_options = True
 
+    _deprecated = True
+
     _func_decomp_old = None
 
     def _init_module(self):

--- a/dedupsqlfs/fuse/compress/base.py
+++ b/dedupsqlfs/fuse/compress/base.py
@@ -212,4 +212,13 @@ class BaseCompressTool(object):
         comp = self._compressors[ method ]
         return comp.decompressData(data)
 
+    def isDeprecated(self, method):
+        """
+        Is (de)compression method deprecated and should not be used
+
+        @return bool
+        """
+        comp = self._compressors[method]
+        return comp.isDeprecated()
+
     pass

--- a/dedupsqlfs/fuse/dedupfs.py
+++ b/dedupsqlfs/fuse/dedupfs.py
@@ -178,6 +178,8 @@ class DedupFS(object): # {{{1
     def decompressData(self, method, compressedBlock):
         return self._compressTool.decompressData(method, compressedBlock)
 
+    def isDeprecated(self, method):
+        return self._compressTool.isDeprecated(method)
 
     def setDataDirectory(self, data_dir_path):
         self.operations.getManager().setBasepath(data_dir_path)


### PR DESCRIPTION
Just rsync over backup and old compression methods should disappear.

By #62 