### PR TITLE
Update for #176

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,9 @@ In the current implementation a file's content DON'T needs to fit in a [cStringI
  instance, which limits the maximum file size to your free RAM. But sometimes you need to tune caching timeouts to
  drop caches more friquently, on massive reads.
 
-There is limit of SQLite database size: about 2 TB with default settings of `pages_count` (2**31) * `page_size` (1024).
- And `page_size` can be set up to 32kB, so database file theoreticaly limited by 32 TB.
- Size of `page_size` would be adjusted automaticaly depends on database file size.
+There is limit of SQLite database size: about 4 TB with default settings of `pages_count` (2**30) * `page_size` (4096).
+ And `page_size` can be set up to 64kB, so database file theoreticaly limited by 64 TB.
+ Size of `page_size` would be adjusted automaticaly depends on database file size, or median of written block size.
 
 Note: dynamic subvolume and snapshot creation available only with MySQL storage engine.
  SQLite is keeping database locked.

--- a/dedupsqlfs/db/mysql/table/_base.py
+++ b/dedupsqlfs/db/mysql/table/_base.py
@@ -54,7 +54,10 @@ class Table( object ):
         if self._engine == "InnoDB":
             _cs += " KEY_BLOCK_SIZE=%d" % self._key_block_size
             if self._compressed:
-                _cs += " ROW_FORMAT=COMPRESSED"
+                if self._manager.getIsMariaDB():
+                    _cs += " ROW_FORMAT=DYNAMIC ROW_COMPRESSED=1"
+                else:
+                    _cs += " ROW_FORMAT=COMPRESSED"
             _cs += ";"
         if self._engine == "TokuDB":
             if not self._compressed:
@@ -138,6 +141,15 @@ class Table( object ):
 
     def getFileSize(self):
         return self.getSize()
+
+    def setPageSize(self, page_size):
+        """
+        Don't do anything.
+        It's emulation of sqlite table function.
+        @param size:
+        @return:
+        """
+        return self
 
     def getSize(self):
         cursor_type = pymysql.cursors.DictCursor

--- a/dedupsqlfs/db/mysql/table/hash_sizes.py
+++ b/dedupsqlfs/db/mysql/table/hash_sizes.py
@@ -105,4 +105,9 @@ class TableHashSizes( Table ):
         self.stopTimer('get_sizes_by_hash_ids')
         return items
 
+    def get_median_compressed_size(self):
+        self.startTimer()
+        self.stopTimer('get_median_compressed_size')
+        return 0
+
     pass

--- a/dedupsqlfs/db/sqlite/table/_base.py
+++ b/dedupsqlfs/db/sqlite/table/_base.py
@@ -130,6 +130,23 @@ class Table( object ):
             self._db_file_path = os.path.abspath(self._db_file_path)
         return self._db_file_path
 
+    def setPageSize(self, page_size):
+        # Sqlite support 512-65536 byte pages
+        for n in range(9,17):
+            ps = 2**n
+            if page_size < ps:
+                page_size = ps
+                break
+
+        if page_size > 2**16:
+            page_size = 2**16
+
+        self._page_size = page_size
+        return self
+
+    def getPageSize(self):
+        return self._page_size
+
     def calcFilePageSize(self):
         db_path = self.getDbFilePath()
 

--- a/dedupsqlfs/db/sqlite/table/_base.py
+++ b/dedupsqlfs/db/sqlite/table/_base.py
@@ -278,7 +278,6 @@ class Table( object ):
             conn.execute("PRAGMA synchronous=NORMAL")
 
         conn.execute("PRAGMA temp_store=FILE")
-        conn.execute("PRAGMA max_page_count=2147483646")
         conn.execute("PRAGMA page_size=%i" % pageSize)
         conn.execute("PRAGMA cache_size=%i" % cacheSize)
 

--- a/dedupsqlfs/db/sqlite/table/block.py
+++ b/dedupsqlfs/db/sqlite/table/block.py
@@ -2,13 +2,10 @@
 
 __author__ = 'sergey'
 
-import sqlite3
+from sqlite3 import Binary
 from dedupsqlfs.db.sqlite.table import Table
 
 class TableBlock( Table ):
-
-    # Use bigger block for data
-    _page_size = 1024*16
 
     _table_name = "block"
 
@@ -32,7 +29,7 @@ class TableBlock( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        bdata = sqlite3.Binary(data)
+        bdata = Binary(data)
 
         cur.execute("INSERT INTO `%s`(hash_id, data) VALUES (?,?)" % self._table_name,
                     (hash_id, bdata,))
@@ -48,7 +45,7 @@ class TableBlock( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        bdata = sqlite3.Binary(data)
+        bdata = Binary(data)
 
         cur.execute("UPDATE `%s` SET data=? WHERE hash_id=?" % self._table_name,
                     (bdata, hash_id,))

--- a/dedupsqlfs/db/sqlite/table/hash.py
+++ b/dedupsqlfs/db/sqlite/table/hash.py
@@ -2,7 +2,7 @@
 
 __author__ = 'sergey'
 
-import sqlite3
+from sqlite3 import Binary
 from dedupsqlfs.db.sqlite.table import Table
 
 class TableHash( Table ):
@@ -25,7 +25,7 @@ class TableHash( Table ):
     def insert( self, value):
         self.startTimer()
         cur = self.getCursor()
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
         cur.execute("INSERT INTO `%s`(hash) VALUES (?)" % self.getName(),
                     (bvalue,))
         item = cur.lastrowid
@@ -35,7 +35,7 @@ class TableHash( Table ):
     def insertRaw( self, rowId, value):
         self.startTimer()
         cur = self.getCursor()
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
         cur.execute("INSERT INTO `%s`(id,hash) VALUES (?,?)" % self.getName(),
                     (rowId,bvalue,))
         item = cur.lastrowid
@@ -49,7 +49,7 @@ class TableHash( Table ):
         """
         self.startTimer()
         cur = self.getCursor()
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
         cur.execute("UPDATE `%s` SET hash=? WHERE id=?" % self.getName(),
                     (bvalue, item_id))
         count = cur.rowcount
@@ -69,7 +69,7 @@ class TableHash( Table ):
     def find( self, value ):
         self.startTimer()
         cur = self.getCursor()
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
         cur.execute("SELECT id FROM `%s` WHERE hash=?" % self.getName(), (bvalue,))
         item = cur.fetchone()
         if item:

--- a/dedupsqlfs/db/sqlite/table/hash_sizes.py
+++ b/dedupsqlfs/db/sqlite/table/hash_sizes.py
@@ -14,7 +14,7 @@ class TableHashSizes( Table ):
         # Create table
         c.execute(
             "CREATE TABLE IF NOT EXISTS `%s` (" % self.getName()+
-                "hash_id INTEGER PRIMARY KEY, "+
+                "`hash_id` INTEGER PRIMARY KEY, "+
                 "`writed_size` INTEGER NOT NULL,"+
                 "`compressed_size` INTEGER NOT NULL"+
             ");"
@@ -89,14 +89,17 @@ class TableHashSizes( Table ):
 
         cur = self.getCursor()
 
-        cur.execute("SELECT SUM(compressed_size) AS s FROM `%s`" % self.getName())
+        cur.execute("SELECT SUM(`compressed_size`) AS `s` FROM `%s`" % self.getName())
         item = cur.fetchone()
+
+        if not item["s"]:
+            return 0
 
         need_sum = item["s"] / 2
 
         cur_sum = 0
         comp_size = 0
-        cur.execute("SELECT compressed_size FROM `%s` " % self.getName())
+        cur.execute("SELECT `compressed_size` FROM `%s` ORDER BY `compressed_size`" % self.getName())
         for _i in iter(cur.fetchone, None):
             cur_sum += _i["compressed_size"]
             if cur_sum > need_sum:

--- a/dedupsqlfs/db/sqlite/table/hash_sizes.py
+++ b/dedupsqlfs/db/sqlite/table/hash_sizes.py
@@ -83,4 +83,27 @@ class TableHashSizes( Table ):
         self.stopTimer('get_sizes_by_hash_ids')
         return items
 
+
+    def get_median_compressed_size(self):
+        self.startTimer()
+
+        cur = self.getCursor()
+
+        cur.execute("SELECT SUM(compressed_size) AS s FROM `%s`" % self.getName())
+        item = cur.fetchone()
+
+        need_sum = item["s"] / 2
+
+        cur_sum = 0
+        comp_size = 0
+        cur.execute("SELECT compressed_size FROM `%s` " % self.getName())
+        for _i in iter(cur.fetchone, None):
+            cur_sum += _i["compressed_size"]
+            if cur_sum > need_sum:
+                break
+            comp_size = _i["compressed_size"]
+
+        self.stopTimer('get_median_compressed_size')
+        return comp_size
+
     pass

--- a/dedupsqlfs/db/sqlite/table/hash_sizes.py
+++ b/dedupsqlfs/db/sqlite/table/hash_sizes.py
@@ -92,10 +92,18 @@ class TableHashSizes( Table ):
         cur.execute("SELECT SUM(`compressed_size`) AS `s` FROM `%s`" % self.getName())
         item = cur.fetchone()
 
-        if not item["s"]:
+        isum = item["s"]
+        if not isum:
             return 0
 
-        need_sum = item["s"] / 2
+        cur.execute("SELECT COUNT(1) AS `c` FROM `%s`" % self.getName())
+        item = cur.fetchone()
+
+        icount = item["c"]
+        if not icount:
+            return 0
+
+        need_sum = isum / 2
 
         cur_sum = 0
         comp_size = 0

--- a/dedupsqlfs/db/sqlite/table/name.py
+++ b/dedupsqlfs/db/sqlite/table/name.py
@@ -2,8 +2,8 @@
 
 __author__ = 'sergey'
 
-import hashlib
-import sqlite3
+from hashlib import md5
+from sqlite3 import Binary
 from dedupsqlfs.db.sqlite.table import Table
 
 class TableName( Table ):
@@ -29,7 +29,7 @@ class TableName( Table ):
         :param value: bytes
         :return: int
         """
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
         return 8 + 16 + len(bvalue)*2
 
     def insert(self, value):
@@ -40,9 +40,9 @@ class TableName( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        digest = sqlite3.Binary(hashlib.new('md5', value).digest())
+        digest = Binary(md5(value).digest())
 
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
 
         cur.execute("INSERT INTO `%s`(hash,value) VALUES (?,?)" % self.getName(), (digest,bvalue,))
         item = cur.lastrowid
@@ -57,9 +57,9 @@ class TableName( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        digest = sqlite3.Binary(hashlib.new('md5', value).digest())
+        digest = Binary(md5(value).digest())
 
-        bvalue = sqlite3.Binary(value)
+        bvalue = Binary(value)
 
         cur.execute("INSERT INTO `%s`(id,hash,value) VALUES (?,?,?)" % self.getName(), (rowId, digest, bvalue,))
         item = cur.lastrowid
@@ -74,7 +74,7 @@ class TableName( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        digest = sqlite3.Binary(hashlib.new('md5', value).digest())
+        digest = Binary(md5(value).digest())
 
         cur.execute("SELECT id FROM `%s` WHERE hash=?" % self._table_name, (digest,))
         item = cur.fetchone()

--- a/dedupsqlfs/db/sqlite/table/subvolume.py
+++ b/dedupsqlfs/db/sqlite/table/subvolume.py
@@ -2,8 +2,8 @@
 
 __author__ = 'sergey'
 
-import hashlib
-import sqlite3
+from hashlib import md5
+from sqlite3 import Binary
 from time import time
 from dedupsqlfs.db.sqlite.table import Table
 
@@ -44,9 +44,9 @@ class TableSubvolume( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        digest = sqlite3.Binary(hashlib.new('md5', name).digest())
+        digest = Binary(md5(name).digest())
 
-        bname = sqlite3.Binary(name)
+        bname = Binary(name)
 
         cur.execute("INSERT INTO `%s`(hash, name, created_at, mounted_at, updated_at, stats_at, stats, root_diff_at, root_diff) " % self.getName()+
                     "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)", (digest, bname, int(created_at), mounted_at, updated_at, stats_at, stats, root_diff_at, root_diff,))
@@ -160,7 +160,7 @@ class TableSubvolume( Table ):
         self.startTimer()
         cur = self.getCursor()
 
-        digest = sqlite3.Binary(hashlib.new('md5', name).digest())
+        digest = Binary(md5(name).digest())
 
         cur.execute(
             "SELECT * FROM `%s` " % self.getName()+

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2457,7 +2457,7 @@ class DedupOperations(llfuse.Operations):  # {{{1
                 self.cached_hash_compress.set(hash_id, cmethod_id)
 
             hash_SZ = self.__get_sizes_by_hash_from_cache(hash_id)
-            if hash_SZ:
+            if hash_SZ and hash_SZ["compressed_size"] > 0 and hash_SZ["writed_size"] > 0:
                 if hash_SZ["compressed_size"] != comp_size or hash_SZ["writed_size"] != writed_size:
                     tableHSZ.update(hash_id, writed_size, comp_size)
                     hash_SZ["compressed_size"] = comp_size

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2638,6 +2638,12 @@ class DedupOperations(llfuse.Operations):  # {{{1
             self.getLogger().debug("Performing data vacuum (this might take a while) ..")
             sz = 0
             dbsz = 0
+
+            hsz = self.getTable('hash_sizes')
+            pts = hsz.get_median_compressed_size()
+            bt = self.getTable('block')
+            bt.setPageSize(pts)
+
             for table_name in self.getManager().tables:
                 dbsz += self.getTable(table_name).getFileSize()
             for table_name in self.getManager().tables:

--- a/dedupsqlfs/fuse/operations.py
+++ b/dedupsqlfs/fuse/operations.py
@@ -2650,7 +2650,11 @@ class DedupOperations(llfuse.Operations):  # {{{1
                 sz += self.__vacuum_datatable(table_name, True)
             elapsed_time = time() - start_time
 
-            diffSign = sz > 0 and '+' or '-'
+            diffSign = ''
+            if sz > 0:
+                diffSign = '+'
+            elif sz < 0:
+                diffSign = '-'
 
             prsz = format_size(abs(sz))
 


### PR DESCRIPTION
- recalculate page size for compressed and written data
- set page size for block table on vaccum action
- use less imports, only needed