### PR TITLE
Use mean compressed block size, not median

### DIFF
--- a/dedupsqlfs/app/actions/vacuum.py
+++ b/dedupsqlfs/app/actions/vacuum.py
@@ -38,9 +38,9 @@ def forced_vacuum(app):
     dbsz = 0
 
     hsz = app.operations.getTable('hash_sizes')
-    pts = hsz.get_median_compressed_size()
+    pagesz = hsz.get_mean_compressed_size()
     bt = app.operations.getTable('block')
-    bt.setPageSize(pts)
+    bt.setPageSize(pagesz)
 
     for table_name in app.operations.getManager().tables:
         dbsz += app.operations.getTable(table_name).getFileSize()

--- a/dedupsqlfs/db/mysql/table/hash_sizes.py
+++ b/dedupsqlfs/db/mysql/table/hash_sizes.py
@@ -110,4 +110,9 @@ class TableHashSizes( Table ):
         self.stopTimer('get_median_compressed_size')
         return 0
 
+    def get_mean_compressed_size(self):
+        self.startTimer()
+        self.stopTimer('get_mean_compressed_size')
+        return 0
+
     pass

--- a/dedupsqlfs/db/sqlite/table/hash_sizes.py
+++ b/dedupsqlfs/db/sqlite/table/hash_sizes.py
@@ -94,6 +94,7 @@ class TableHashSizes( Table ):
 
         isum = item["s"]
         if not isum:
+            self.stopTimer('get_median_compressed_size')
             return 0
 
         cur.execute("SELECT COUNT(1) AS `c` FROM `%s`" % self.getName())
@@ -101,6 +102,7 @@ class TableHashSizes( Table ):
 
         icount = item["c"]
         if not icount:
+            self.stopTimer('get_median_compressed_size')
             return 0
 
         need_sum = isum / 2
@@ -116,5 +118,31 @@ class TableHashSizes( Table ):
 
         self.stopTimer('get_median_compressed_size')
         return comp_size
+
+    def get_mean_compressed_size(self):
+        self.startTimer()
+
+        cur = self.getCursor()
+
+        cur.execute("SELECT SUM(`compressed_size`) AS `s` FROM `%s`" % self.getName())
+        item = cur.fetchone()
+
+        isum = item["s"]
+        if not isum:
+            self.stopTimer('get_mean_compressed_size')
+            return 0
+
+        cur.execute("SELECT COUNT(1) AS `c` FROM `%s`" % self.getName())
+        item = cur.fetchone()
+
+        icount = item["c"]
+        if not icount:
+            self.stopTimer('get_mean_compressed_size')
+            return 0
+
+        result = isum / icount
+
+        self.stopTimer('get_mean_compressed_size')
+        return result
 
     pass


### PR DESCRIPTION
For #188 